### PR TITLE
fix routing issue with refresh

### DIFF
--- a/back/cmd/api/routes.go
+++ b/back/cmd/api/routes.go
@@ -34,8 +34,8 @@ func (app *application) routes() http.Handler {
 			http.ServeFile(w, r, requestedPath)
 			return
 		}
-		// Otherwise serve index.html
-		http.ServeFile(w, r, filepath.Join(outDir, "index.html"))
+		// serve index.html if the route is a directory
+		http.ServeFile(w, r, filepath.Join(requestedPath, "index.html"))
 	})
 	return app.recoverPanic(app.enableCORS(app.rateLimit(app.authenticate(router))))
 }

--- a/front/textcare/next.config.ts
+++ b/front/textcare/next.config.ts
@@ -2,14 +2,14 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
     output: "export",
+    // Change links `/me` -> `/me/` and emit `/me.html` -> `/me/index.html`
+    trailingSlash: true,
+    // allow project to build in production with ESLint errors
     eslint: {
-        // Warning: This allows production builds to successfully complete even if
-        // your project has ESLint errors.
         ignoreDuringBuilds: true,
     },
+    // allow project to build in production with ESLint errors
     typescript: {
-        // Warning: This allows production builds to successfully complete even if
-        // your project has type errors.
         ignoreBuildErrors: true,
     },
 };


### PR DESCRIPTION
if user refreshed page manually in browser correct page was not being displayed due to go backend not serving correct directory and incorrect next js config for static build